### PR TITLE
Improve ATMMetaForce XML field names

### DIFF
--- a/serialization/src/ATMMetaForceProxy.cpp
+++ b/serialization/src/ATMMetaForceProxy.cpp
@@ -25,7 +25,7 @@ void ATMMetaForceProxy::serialize(const void* object, OpenMM::SerializationNode&
     node.setDoubleProperty("aCore", force.getDefaultAcore());
     node.setDoubleProperty("direction", force.getDefaultDirection());
 
-    OpenMM::SerializationNode& variableForceGroups = node.createChildNode("GlobalParameters");
+    OpenMM::SerializationNode& variableForceGroups = node.createChildNode("VariableForceGroups");
     for (const auto i : force.getVariableForceGroups()) {
         variableForceGroups.createChildNode("Parameter").setIntProperty("group", i);
     }
@@ -47,7 +47,7 @@ void* ATMMetaForceProxy::deserialize(const OpenMM::SerializationNode& node) cons
     try {
         std::vector<int> variableForceGroups;
 
-        const OpenMM::SerializationNode& globalParams = node.getChildNode("GlobalParameters");
+        const OpenMM::SerializationNode& globalParams = node.getChildNode("VariableForceGroups");
         for (auto& parameter : globalParams.getChildren())
             variableForceGroups.push_back(parameter.getIntProperty("group"));
 


### PR DESCRIPTION
This PR adds the suggestion in #5 for more accurate names in the XML representation. The serialised force now looks like:

```
<Force aCore=".07"
       alpha=".25"
       direction="0"
       forceGroup="30"
       lambda1="0"
       lambda2=".1"
       name="MyATMMetaForce"
       type="ATMMetaForce"
       u0=".5"
       uMax="200"
       ubCore="100"
       version="0"
       w0=".6">
    <VariableForceGroups>
        <Parameter group="1"/>
    </VariableForceGroups>
    <Particles>
        <Particle dx=".1" dy=".2" dz=".3" particle="0"/>
        <Particle dx=".4" dy=".5" dz=".6" particle="2"/>
    </Particles>
</Force>
``` 

@egallicc please let me know if you'd like any other attribute names to be changed and I'll happily update them!

Fixes #4